### PR TITLE
Various edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+cache: pip
+python:
+  - "3.6"
+env:
+  - BASEDIR="https://raw.githubusercontent.com/open-contracting/standard-maintenance-scripts/master"
+install:
+  - curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
+script:
+  - curl -s -S --retry 3 $BASEDIR/tests/script.sh | bash -

--- a/README.md
+++ b/README.md
@@ -1,5 +1,35 @@
 # Number of tenderers extension for TED data
 
-> OCDS extension to describe the minimum, maximum or estimated number of tenderers, compatible with TED form F02, section II 2.9. This data is not included in eForms.
+Adds a second stage object to the lot object, to describe the second stage of a two-stage procedure. In particular, it adds two fields to describe the limits on the number of candidates to be invited.
 
-This extension aims primarily at supporting the expression of limits in the number of invited tenderers for closed procedures, formatted according to TED v2.0.9 schema (form F02, section II 2.9).
+## Guidance
+
+If there is an exact limit on the number of candidates, set `minimumCandidates` and `maximumCandidates` to the same number.
+
+If `maximumCandidates` is set, `eligibilityCriteria` can be used for the brief description of the selection criteria and how the selection criteria will be used to select candidates to be invited for the second stage.
+
+## Legal context
+
+In the European Union, this extension's fields correspond to [eForms BG-709 (Second Stage)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+
+## Example
+
+```json
+{
+  "tender": {
+    "lots": [
+      {
+        "id": "1",
+        "secondStage": {
+          "minimumCandidates": 5,
+          "maximumCandidates": 50
+        }
+      }
+    ]
+  }
+}
+```
+
+## Issues
+
+Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.

--- a/extension.json
+++ b/extension.json
@@ -1,17 +1,20 @@
 {
   "name": {
-    "en": "EU number of tenderers"
+    "en": "Second stage candidate limit"
   },
   "description": {
-    "en": "This extension aims primarily at supporting the expression of limits in the number of invited tenderers for closed procedures, formatted according to TED v2.0.9 schema (form F02, section II 2.9). This information is not supported by eForms."
+    "en": "Adds a second stage object to the lot object, to describe the second stage of a two-stage procedure."
   },
   "documentationUrl": {
-    "en": "https://github.com/open-contracting-extensions/ocds_tenderers_number_extension"
+    "en": "https://github.com/open-contracting-extensions/ocds_candidateLimit_extension"
   },
   "compatibility": [
     "1.1"
   ],
   "schemas": [
     "release-schema.json"
+  ],
+  "dependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
   ]
 }

--- a/extension.json
+++ b/extension.json
@@ -13,5 +13,5 @@
   ],
   "schemas": [
     "release-schema.json"
-]
+  ]
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -2,26 +2,38 @@
   "definitions": {
     "Tender": {
       "properties": {
-          "envisagedNumberTenderers": {
-              "title": "Envisaged number of tenderers",
-              "description": "The number of tenderers envisaged by the procuring entitiy.",
-              "type": ["null","number"]
-          },
-          "envisagedMinimumNumberTenderers": {
-              "title": "Envisaged minimum number of tenderers",
-              "description": "Envisaged minimum number of tenderers when the envisaged number of tenderers is expressed as a range.",
-              "type": ["number","null"]
-          },
-          "envisagedMaximumNumberTenderers": {
-              "title": "Envisaged maximum number of tenderers",
-              "description": "Envisaged maximum number of tenderers when the envisaged number of tenderers is expressed as a range.",
-              "type": ["number","null"]
-          },
-          "envisagedNumberTenderersRationale": {
-              "title": "Rationale for the envisaged number of tenderers",
-              "description": "The rationale for the provided limits of tenderers.",
-              "type": ["string","null"]
-          }
+        "envisagedNumberTenderers": {
+          "title": "Envisaged number of tenderers",
+          "description": "The number of tenderers envisaged by the procuring entitiy.",
+          "type": [
+            "null",
+            "number"
+          ]
+        },
+        "envisagedMinimumNumberTenderers": {
+          "title": "Envisaged minimum number of tenderers",
+          "description": "Envisaged minimum number of tenderers when the envisaged number of tenderers is expressed as a range.",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "envisagedMaximumNumberTenderers": {
+          "title": "Envisaged maximum number of tenderers",
+          "description": "Envisaged maximum number of tenderers when the envisaged number of tenderers is expressed as a range.",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "envisagedNumberTenderersRationale": {
+          "title": "Rationale for the envisaged number of tenderers",
+          "description": "The rationale for the provided limits of tenderers.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     }
   }

--- a/release-schema.json
+++ b/release-schema.json
@@ -1,38 +1,29 @@
 {
   "definitions": {
-    "Tender": {
+    "Lot": {
       "properties": {
-        "envisagedNumberTenderers": {
-          "title": "Envisaged number of tenderers",
-          "description": "The number of tenderers envisaged by the procuring entitiy.",
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "envisagedMinimumNumberTenderers": {
-          "title": "Envisaged minimum number of tenderers",
-          "description": "Envisaged minimum number of tenderers when the envisaged number of tenderers is expressed as a range.",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "envisagedMaximumNumberTenderers": {
-          "title": "Envisaged maximum number of tenderers",
-          "description": "Envisaged maximum number of tenderers when the envisaged number of tenderers is expressed as a range.",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "envisagedNumberTenderersRationale": {
-          "title": "Rationale for the envisaged number of tenderers",
-          "description": "The rationale for the provided limits of tenderers.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "secondStage": {
+          "title": "Second stage",
+          "description": "Information about the second stage of a two-stage procedure (e.g. a restricted procedure, a competitive procedure with negotiation, a competitive dialogue or an innovation partnership).",
+          "type": "object",
+          "properties": {
+            "minimumCandidates": {
+              "title": "Minimum number of candidates",
+              "description": "The minimum number of candidates to be invited for the second stage of the procedure.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "maximumCandidates": {
+              "title": "Maximum number of candidates",
+              "description": "The maximum number of candidates to be invited for the second stage of the procedure.",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
(Getting late to describe changes. Maybe tomorrow.)

In addition to changes listed by @ColinMaudry below:

Schema

* Put fields under a `secondStage` object, in case we add future fields to describe the second stage
* Rename properties to use 'Candidates' instead of 'Tenderers' to avoid confusion with parties in first stage
* Remove `envisagedNumberTenderers` and instead set min/max to same number to express an exact limit
* Remove `envisagedNumberTenderersRationale` as this will need to go on a selection criteria extension for eForms